### PR TITLE
Update Runtime Version to 48 (and blueprint to 0.16.0)

### DIFF
--- a/app.drey.Dialect.json
+++ b/app.drey.Dialect.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "app.drey.Dialect",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "dialect",
     "finish-args" : [
@@ -24,8 +24,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.10.0",
-                    "commit": "2a39a16391122af2f3d812e478c1c1398c98b972"
+                    "tag": "v0.16.0",
+                    "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0"
                 }
             ]
         },


### PR DESCRIPTION
New runtime brings altered dark theme and corner radii of Libadwaita 1.7; requires blueprint update